### PR TITLE
integrate prettier and eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "prettier"
+  ],
   "env": {
     "browser": true,
     "jest": true
@@ -31,7 +34,6 @@
           "**/*.test.jsx?"
         ]
       }
-    ],
-    "no-else-return": "off"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "enzyme-to-json": "^3.3.3",
     "eslint": "^4.9.0",
     "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",

--- a/src/store.js
+++ b/src/store.js
@@ -23,16 +23,18 @@ const getMiddleware = () => {
     return applyMiddleware(
       reduxRouterMiddleware,
       queryParamsParserMiddleware,
-      thunkMiddleware,
-    );
-  } else {
-    return applyMiddleware(
-      createLogger(),
-      reduxRouterMiddleware,
-      queryParamsParserMiddleware,
-      thunkMiddleware,
+      thunkMiddleware
     );
   }
+  return applyMiddleware(
+    createLogger(),
+    reduxRouterMiddleware,
+    queryParamsParserMiddleware,
+    thunkMiddleware
+  );
 };
 
-export const store = createStore(reducers, composeWithDevTools(getMiddleware()));
+export const store = createStore(
+  reducers,
+  composeWithDevTools(getMiddleware())
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,6 +2737,12 @@ eslint-config-airbnb@^16.1.0:
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
 
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-config-react-app@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz#23c909f71cbaff76b945b831d2d814b8bde169eb"
@@ -3494,6 +3500,10 @@ get-caller-file@^1.0.1:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Disables formatting related rules in eslint config so that prettier
will not break eslint all the time.