### PR TITLE
remove logs of `undefined` actions

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -27,10 +27,10 @@ const getMiddleware = () => {
     );
   }
   return applyMiddleware(
-    createLogger(),
     reduxRouterMiddleware,
     queryParamsParserMiddleware,
-    thunkMiddleware
+    thunkMiddleware,
+    createLogger()
   );
 };
 


### PR DESCRIPTION
User Story: INSPIR-869

Found [here](https://github.com/reduxjs/redux-thunk/issues/91), that the order of applying middleware matters (logger should be last).

Generated log:
![screenshot from 2018-06-11 13-34-22](https://user-images.githubusercontent.com/11242410/41229417-3615545a-6d7c-11e8-81c4-9d3353853540.png)


Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>