### PR TITLE
AuthorLink: use new fields to display name

### DIFF
--- a/src/literature/components/AuthorLink.jsx
+++ b/src/literature/components/AuthorLink.jsx
@@ -39,10 +39,13 @@ class AuthorLink extends Component {
   render() {
     const { author } = this.props;
     const authorHref = this.getAuthorHref();
+    const firstName = author.get('first_name');
+    const lastName = author.get('last_name', '');
+
     return (
       <div className="di">
         <a target="_blank" href={authorHref}>
-          {author.get('full_name')}
+          {`${firstName} ${lastName}`}
         </a>
         {this.renderAffiliationLink()}
       </div>

--- a/src/literature/components/__tests__/AuthorLink.test.jsx
+++ b/src/literature/components/__tests__/AuthorLink.test.jsx
@@ -8,6 +8,8 @@ describe('AuthorLink', () => {
   it('renders with full author', () => {
     const author = fromJS({
       full_name: 'Name, Full',
+      first_name: 'Full',
+      last_name: 'Name',
       affiliations: [
         {
           value: 'Affiliation',
@@ -21,6 +23,8 @@ describe('AuthorLink', () => {
   it('renders full author without recordId', () => {
     const author = fromJS({
       full_name: 'Name, Full',
+      first_name: 'Full',
+      last_name: 'Name',
       affiliations: [
         {
           value: 'Affiliation',
@@ -31,9 +35,25 @@ describe('AuthorLink', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders atuhor with only full_name', () => {
+  it('renders full author without last_name', () => {
+    const author = fromJS({
+      full_name: 'Name Full',
+      first_name: 'Name Full',
+      affiliations: [
+        {
+          value: 'Affiliation',
+        },
+      ],
+    });
+    const wrapper = shallow(<AuthorLink author={author} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders author with only name fields', () => {
     const author = fromJS({
       full_name: 'Name, Full',
+      first_name: 'Full',
+      last_name: 'Name',
     });
     const wrapper = shallow(<AuthorLink recordId={12345} author={author} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/literature/components/__tests__/__snapshots__/AuthorLink.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/AuthorLink.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AuthorLink renders atuhor with only full_name 1`] = `
+exports[`AuthorLink renders author with only name fields 1`] = `
 <div
   className="di"
 >
@@ -8,8 +8,33 @@ exports[`AuthorLink renders atuhor with only full_name 1`] = `
     href="//inspirehep.net/author/profile/Name, Full?recid=12345"
     target="_blank"
   >
-    Name, Full
+    Full Name
   </a>
+</div>
+`;
+
+exports[`AuthorLink renders full author without last_name 1`] = `
+<div
+  className="di"
+>
+  <a
+    href="//inspirehep.net/author/profile/Name Full"
+    target="_blank"
+  >
+    Name Full 
+  </a>
+  <span
+    className="pl1 grey"
+  >
+    (
+    <a
+      href="//inspirehep.net/search?cc=Institutions&p=institution:\\"Affiliation\\""
+      target="_blank"
+    >
+      Affiliation
+    </a>
+    )
+  </span>
 </div>
 `;
 
@@ -21,7 +46,7 @@ exports[`AuthorLink renders full author without recordId 1`] = `
     href="//inspirehep.net/author/profile/Name, Full"
     target="_blank"
   >
-    Name, Full
+    Full Name
   </a>
   <span
     className="pl1 grey"
@@ -46,7 +71,7 @@ exports[`AuthorLink renders with full author 1`] = `
     href="//inspirehep.net/author/profile/Name, Full?recid=12345"
     target="_blank"
   >
-    Name, Full
+    Full Name
   </a>
   <span
     className="pl1 grey"


### PR DESCRIPTION
Use `first_name` and `last_name` fields instead of splitting `full_name`
in order to display the author's name in a 'first_name last_name' format.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>