### PR TITLE
CollaborationList: separation of collaborations

### DIFF
--- a/src/common/components/InlineList/InlineList.scss
+++ b/src/common/components/InlineList/InlineList.scss
@@ -12,6 +12,11 @@
       content: '; ';
     }
   }
+  ul.separate-items-with-comma {
+    li:not(:last-child):after {
+      content: ', ';
+    }
+  }
   ul.separate-items-with-and {
     li:not(:last-child):after {
       content: ' and ';

--- a/src/literature/components/CollaborationList.jsx
+++ b/src/literature/components/CollaborationList.jsx
@@ -1,51 +1,66 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { List } from 'immutable';
 
 import CollaborationLink from './CollaborationLink';
 import InlineList from '../../common/components/InlineList';
 
+const REGEX_COLLABORATIONS_WITH_SUFFIX = /(group|groups|force|consortium|team)$/i;
+
 class CollaborationList extends Component {
-  constructor(props) {
-    super(props);
-
-    this.renderSuffix = this.renderSuffix.bind(this);
-  }
-
-  renderSuffix() {
-    const { collaborations } = this.props;
-    return (
-      <span className="pl1 pr1">
-        {collaborations.size > 1 ? 'Collaborations' : 'Collaboration'}
-      </span>
-    );
+  static collaborationMatchSuffix(item) {
+    return item.get('value').match(REGEX_COLLABORATIONS_WITH_SUFFIX);
   }
 
   render() {
-    const { collaborations, wrapperClassName } = this.props;
-    return collaborations.isEmpty() ? null : (
-      <InlineList
-        wrapperClassName={wrapperClassName}
-        separateItemsClassName="separate-items-with-and"
-        items={collaborations}
-        suffix={this.renderSuffix()}
-        extractKey={collaboration => collaboration.get('value')}
-        renderItem={collaboration => (
-          <CollaborationLink>{collaboration.get('value')}</CollaborationLink>
-        )}
-      />
+    const { collaborations } = this.props;
+    const collaborationsWithSuffix = collaborations.filter(
+      CollaborationList.collaborationMatchSuffix
+    );
+    const collaborationsWithoutSuffix = collaborations.filterNot(
+      CollaborationList.collaborationMatchSuffix
+    );
+
+    return (
+      <Fragment>
+        <InlineList
+          wrapperClassName="di"
+          separateItemsClassName="separate-items-with-and"
+          items={collaborationsWithoutSuffix}
+          suffix={
+            collaborationsWithoutSuffix.size > 0 && (
+              <span className="pr1">
+                {collaborationsWithoutSuffix.size > 1
+                  ? ' Collaborations'
+                  : ' Collaboration'}
+              </span>
+            )
+          }
+          extractKey={collaboration => collaboration.get('value')}
+          renderItem={collaboration => (
+            <CollaborationLink>{collaboration.get('value')}</CollaborationLink>
+          )}
+        />
+        <InlineList
+          wrapperClassName="di"
+          separateItemsClassName="separate-items-with-comma"
+          items={collaborationsWithSuffix}
+          extractKey={collaboration => collaboration.get('value')}
+          renderItem={collaboration => (
+            <CollaborationLink>{collaboration.get('value')}</CollaborationLink>
+          )}
+        />
+      </Fragment>
     );
   }
 }
 
 CollaborationList.propTypes = {
   collaborations: PropTypes.instanceOf(List),
-  wrapperClassName: PropTypes.string,
 };
 
 CollaborationList.defaultProps = {
   collaborations: List(),
-  wrapperClassName: null,
 };
 
 export default CollaborationList;

--- a/src/literature/components/__tests__/CollaborationList.test.jsx
+++ b/src/literature/components/__tests__/CollaborationList.test.jsx
@@ -5,15 +5,15 @@ import { fromJS } from 'immutable';
 import CollaborationList from '../CollaborationList';
 
 describe('CollaborationList', () => {
-  it('renders with collaboration', () => {
+  it('renders with collaboration without suffix', () => {
     const collaborations = fromJS([{ value: 'Alias Investigations' }]);
     const wrapper = shallow(
       <CollaborationList collaborations={collaborations} />
     );
-    expect(wrapper.dive()).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders with collaborations', () => {
+  it('renders with collaborations without suffix', () => {
     const collaborations = fromJS([
       { value: 'Alias Investigations' },
       { value: 'Nelson and Murdock' },
@@ -21,6 +21,37 @@ describe('CollaborationList', () => {
     const wrapper = shallow(
       <CollaborationList collaborations={collaborations} />
     );
-    expect(wrapper.dive()).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with collaborations with and without suffix', () => {
+    const collaborations = fromJS([
+      { value: 'Alias Investigations' },
+      { value: 'Nelson and Murdock' },
+      { value: 'Defenders Group and Avengers' },
+      { value: 'Defenders Task Force and Avengers' },
+      { value: 'Avangers Groups' },
+      { value: 'Avangers Task Force' },
+      { value: 'Avangers Consortium' },
+      { value: 'Avangers Team' },
+    ]);
+    const wrapper = shallow(
+      <CollaborationList collaborations={collaborations} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with collaborations with suffix', () => {
+    const collaborations = fromJS([
+      { value: 'Avangers Groups' },
+      { value: 'Avangers Group' },
+      { value: 'Avangers Task Force' },
+      { value: 'Avangers Consortium' },
+      { value: 'Avangers Team' },
+    ]);
+    const wrapper = shallow(
+      <CollaborationList collaborations={collaborations} />
+    );
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/literature/components/__tests__/__snapshots__/CollaborationList.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/CollaborationList.test.jsx.snap
@@ -1,54 +1,191 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CollaborationList renders with collaboration 1`] = `
-<div
-  className="__InlineList__"
->
-  <ul
-    className="separate-items-with-and"
-  >
-    <li
-      key="Alias Investigations"
-    >
-      <CollaborationLink>
-        Alias Investigations
-      </CollaborationLink>
-    </li>
-  </ul>
-  <span
-    className="pl1 pr1"
-  >
-    Collaboration
-  </span>
-</div>
+exports[`CollaborationList renders with collaboration without suffix 1`] = `
+<React.Fragment>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          value: "Alias Investigations",
+        },
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={
+      <span
+        className="pr1"
+      >
+         Collaboration
+      </span>
+    }
+    wrapperClassName="di"
+  />
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-comma"
+    suffix={null}
+    wrapperClassName="di"
+  />
+</React.Fragment>
 `;
 
-exports[`CollaborationList renders with collaborations 1`] = `
-<div
-  className="__InlineList__"
->
-  <ul
-    className="separate-items-with-and"
-  >
-    <li
-      key="Alias Investigations"
-    >
-      <CollaborationLink>
-        Alias Investigations
-      </CollaborationLink>
-    </li>
-    <li
-      key="Nelson and Murdock"
-    >
-      <CollaborationLink>
-        Nelson and Murdock
-      </CollaborationLink>
-    </li>
-  </ul>
-  <span
-    className="pl1 pr1"
-  >
-    Collaborations
-  </span>
-</div>
+exports[`CollaborationList renders with collaborations with and without suffix 1`] = `
+<React.Fragment>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          value: "Alias Investigations",
+        },
+        Immutable.Map {
+          value: "Nelson and Murdock",
+        },
+        Immutable.Map {
+          value: "Defenders Group and Avengers",
+        },
+        Immutable.Map {
+          value: "Defenders Task Force and Avengers",
+        },
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={
+      <span
+        className="pr1"
+      >
+         Collaborations
+      </span>
+    }
+    wrapperClassName="di"
+  />
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          value: "Avangers Groups",
+        },
+        Immutable.Map {
+          value: "Avangers Task Force",
+        },
+        Immutable.Map {
+          value: "Avangers Consortium",
+        },
+        Immutable.Map {
+          value: "Avangers Team",
+        },
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-comma"
+    suffix={null}
+    wrapperClassName="di"
+  />
+</React.Fragment>
+`;
+
+exports[`CollaborationList renders with collaborations with suffix 1`] = `
+<React.Fragment>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={false}
+    wrapperClassName="di"
+  />
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          value: "Avangers Groups",
+        },
+        Immutable.Map {
+          value: "Avangers Group",
+        },
+        Immutable.Map {
+          value: "Avangers Task Force",
+        },
+        Immutable.Map {
+          value: "Avangers Consortium",
+        },
+        Immutable.Map {
+          value: "Avangers Team",
+        },
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-comma"
+    suffix={null}
+    wrapperClassName="di"
+  />
+</React.Fragment>
+`;
+
+exports[`CollaborationList renders with collaborations without suffix 1`] = `
+<React.Fragment>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          value: "Alias Investigations",
+        },
+        Immutable.Map {
+          value: "Nelson and Murdock",
+        },
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-and"
+    suffix={
+      <span
+        className="pr1"
+      >
+         Collaborations
+      </span>
+    }
+    wrapperClassName="di"
+  />
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-comma"
+    suffix={null}
+    wrapperClassName="di"
+  />
+</React.Fragment>
 `;

--- a/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
@@ -26,7 +26,6 @@ exports[`LiteratureItem does not arxiv pdf download action if there is no eprint
           Immutable.List [
           ]
         }
-        wrapperClassName={null}
       />
       <AuthorList
         authors={
@@ -93,7 +92,6 @@ exports[`LiteratureItem does not render citation and reference count if they are
           Immutable.List [
           ]
         }
-        wrapperClassName={null}
       />
       <AuthorList
         authors={
@@ -185,7 +183,6 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
           Immutable.List [
           ]
         }
-        wrapperClassName={null}
       />
       <AuthorList
         authors={


### PR DESCRIPTION
* Separates the collaborations into two types, with prefix which are
  collaborations that contain group, force, consortium or team and
  without prefix in which we add Collaboration suffix.

Signed-off-by: Harris Tzovanakis <me@drjova.com>