### PR TITLE
literature: display supervisors in detailed view

### DIFF
--- a/src/literature/components/AuthorList.jsx
+++ b/src/literature/components/AuthorList.jsx
@@ -41,9 +41,16 @@ class AuthorList extends Component {
   }
 
   renderAuthorList(authorsToDisplay, displayShowAll = true) {
-    const { authors, limit, recordId, wrapperClassName } = this.props;
+    const {
+      authors,
+      limit,
+      recordId,
+      wrapperClassName,
+      forSupervisors,
+    } = this.props;
     return (
       <InlineList
+        label={forSupervisors ? 'Supervisor(s)' : null}
         wrapperClassName={wrapperClassName}
         items={authorsToDisplay}
         suffix={
@@ -61,13 +68,14 @@ class AuthorList extends Component {
 
   render() {
     const { modalVisible } = this.state;
-    const { authors, limit, total } = this.props;
+    const { authors, limit, total, forSupervisors } = this.props;
     const showTotal = total === -1 ? authors.size : total;
+    const supervisorsOrAuthors = forSupervisors ? 'supervisors' : 'authors';
     return (
       <Fragment>
         {this.renderAuthorList(authors.take(limit))}
         <Modal
-          title={`${showTotal} authors`}
+          title={`${showTotal} ${supervisorsOrAuthors}`}
           width="50%"
           visible={modalVisible}
           footer={null}
@@ -87,6 +95,7 @@ AuthorList.propTypes = {
   enableShowAll: PropTypes.bool,
   total: PropTypes.number,
   wrapperClassName: PropTypes.string,
+  forSupervisors: PropTypes.bool,
 };
 
 AuthorList.defaultProps = {
@@ -96,6 +105,7 @@ AuthorList.defaultProps = {
   enableShowAll: false,
   total: -1,
   wrapperClassName: null,
+  forSupervisors: false,
 };
 
 export default AuthorList;

--- a/src/literature/components/__tests__/AuthorList.test.jsx
+++ b/src/literature/components/__tests__/AuthorList.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { fromJS } from 'immutable';
+import { Modal } from 'antd';
 
 import AuthorList from '../AuthorList';
-import AuthorLink from '../AuthorLink';
+import InlineList from '../../../common/components/InlineList';
 
 describe('AuthorList', () => {
   it('renders only 5 authors and suffixes "show all" if passed more', () => {
@@ -127,13 +128,73 @@ describe('AuthorList', () => {
       <AuthorList limit={4} recordId={12345} authors={authors} />
     );
 
-    // Fragment make the ``dive`` a bit more difficult
+    // Can not dive since root is a Fragment
     expect(
       wrapper
-        .find('InlineList')
+        .find(InlineList)
         .first()
         .dive()
-        .find(AuthorLink).length
-    ).toBe(1);
+    ).toMatchSnapshot();
+  });
+
+  it('prefixes `Supervisor(s)` when supervisors are passed', () => {
+    const supervisors = fromJS([
+      {
+        full_name: 'Test, Guy 1',
+      },
+    ]);
+    const wrapper = shallow(
+      <AuthorList
+        label="Supervisor(s)"
+        authors={supervisors}
+        recordId={12345}
+        forSupervisors
+      />
+    );
+    expect(
+      wrapper
+        .find(InlineList)
+        .first()
+        .dive()
+    ).toMatchSnapshot();
+  });
+
+  it('should display `authors` in modal title by default', () => {
+    const authors = fromJS([
+      {
+        full_name: 'Test, Guy 1',
+      },
+    ]);
+    const wrapper = shallow(
+      <AuthorList label="Supervisor(s)" authors={authors} recordId={12345} />
+    );
+    expect(
+      wrapper
+        .find(Modal)
+        .first()
+        .dive()
+    ).toMatchSnapshot();
+  });
+
+  it('should show `supervisors` in modal title if supervisors are passed', () => {
+    const supervisors = fromJS([
+      {
+        full_name: 'Test, Guy 1',
+      },
+    ]);
+    const wrapper = shallow(
+      <AuthorList
+        label="Supervisor(s)"
+        authors={supervisors}
+        recordId={12345}
+        forSupervisors
+      />
+    );
+    expect(
+      wrapper
+        .find(Modal)
+        .first()
+        .dive()
+    ).toMatchSnapshot();
   });
 });

--- a/src/literature/components/__tests__/__snapshots__/AuthorList.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/AuthorList.test.jsx.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AuthorList prefixes \`Supervisor(s)\` when supervisors are passed 1`] = `
+<div
+  className="__InlineList__"
+>
+  <span>
+    Supervisor(s)
+    : 
+  </span>
+  <ul
+    className="separate-items-with-semicolon"
+  >
+    <li
+      key="Test, Guy 1"
+    >
+      <AuthorLink
+        author={
+          Immutable.Map {
+            full_name: "Test, Guy 1",
+          }
+        }
+        recordId={12345}
+      />
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`AuthorList renders all authors if they are less than the limit without suffix 1`] = `
 <React.Fragment>
   <InlineList
@@ -54,6 +81,29 @@ exports[`AuthorList renders all authors if they are less than the limit without 
     />
   </Modal>
 </React.Fragment>
+`;
+
+exports[`AuthorList renders authors by using AuthorLink 1`] = `
+<div
+  className="__InlineList__"
+>
+  <ul
+    className="separate-items-with-semicolon"
+  >
+    <li
+      key="Test, Guy 1"
+    >
+      <AuthorLink
+        author={
+          Immutable.Map {
+            full_name: "Test, Guy 1",
+          }
+        }
+        recordId={12345}
+      />
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`AuthorList renders only 5 authors and suffixes "et al." if passed more 1`] = `
@@ -358,4 +408,70 @@ exports[`AuthorList renders only limited (prop) authors and suffixes "show all."
     />
   </Modal>
 </React.Fragment>
+`;
+
+exports[`AuthorList should display \`authors\` in modal title by default 1`] = `
+<DialogWrap
+  confirmLoading={false}
+  footer={null}
+  maskTransitionName="fade"
+  okType="primary"
+  onCancel={[Function]}
+  onClose={[Function]}
+  prefixCls="ant-modal"
+  title="1 authors"
+  transitionName="zoom"
+  visible={false}
+  width="50%"
+>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          full_name: "Test, Guy 1",
+        },
+      ]
+    }
+    label={null}
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-semicolon"
+    suffix={null}
+    wrapperClassName={null}
+  />
+</DialogWrap>
+`;
+
+exports[`AuthorList should show \`supervisors\` in modal title if supervisors are passed 1`] = `
+<DialogWrap
+  confirmLoading={false}
+  footer={null}
+  maskTransitionName="fade"
+  okType="primary"
+  onCancel={[Function]}
+  onClose={[Function]}
+  prefixCls="ant-modal"
+  title="1 supervisors"
+  transitionName="zoom"
+  visible={false}
+  width="50%"
+>
+  <InlineList
+    extractKey={[Function]}
+    items={
+      Immutable.List [
+        Immutable.Map {
+          full_name: "Test, Guy 1",
+        },
+      ]
+    }
+    label="Supervisor(s)"
+    renderItem={[Function]}
+    separateItems={true}
+    separateItemsClassName="separate-items-with-semicolon"
+    suffix={null}
+    wrapperClassName={null}
+  />
+</DialogWrap>
 `;

--- a/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
@@ -33,6 +33,7 @@ exports[`LiteratureItem does not arxiv pdf download action if there is no eprint
           ]
         }
         enableShowAll={false}
+        forSupervisors={false}
         limit={5}
         recordId={12345}
         total={-1}
@@ -99,6 +100,7 @@ exports[`LiteratureItem does not render citation and reference count if they are
           ]
         }
         enableShowAll={false}
+        forSupervisors={false}
         limit={5}
         recordId={12345}
         total={-1}
@@ -193,6 +195,7 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
           ]
         }
         enableShowAll={false}
+        forSupervisors={false}
         limit={5}
         recordId={12345}
         total={-1}

--- a/src/literature/components/__tests__/__snapshots__/ReferenceItem.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/ReferenceItem.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`ReferenceItem renders unlinked reference (no control_number) 1`] = `
             ]
           }
           enableShowAll={false}
+          forSupervisors={false}
           limit={5}
           recordId={undefined}
           total={-1}
@@ -54,6 +55,7 @@ exports[`ReferenceItem renders with full reference 1`] = `
             ]
           }
           enableShowAll={false}
+          forSupervisors={false}
           limit={5}
           recordId={12345}
           total={-1}

--- a/src/literature/containers/DetailPage/DetailPage.jsx
+++ b/src/literature/containers/DetailPage/DetailPage.jsx
@@ -49,7 +49,7 @@ class DetailPage extends Component {
   }
 
   render() {
-    const { authors, references, loadingReferences } = this.props;
+    const { authors, references, loadingReferences, supervisors } = this.props;
 
     const { record } = this.props;
     const metadata = record.get('metadata');
@@ -102,6 +102,12 @@ class DetailPage extends Component {
                 limit={collaborations ? 1 : 5}
                 enableShowAll
               />
+              <AuthorList
+                recordId={recordId}
+                authors={supervisors}
+                forSupervisors
+                enableShowAll
+              />
             </div>
             <LiteratureDate date={date} />
             <div className="mt3">
@@ -150,6 +156,7 @@ DetailPage.propTypes = {
   record: PropTypes.instanceOf(Map).isRequired,
   references: PropTypes.instanceOf(List).isRequired,
   authors: PropTypes.instanceOf(List).isRequired,
+  supervisors: PropTypes.instanceOf(List).isRequired,
   loadingReferences: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
 };
@@ -160,6 +167,7 @@ const mapStateToProps = state => ({
   references: state.literature.get('references'),
   loadingReferences: state.literature.get('loadingReferences'),
   authors: state.literature.get('authors'),
+  supervisors: state.literature.get('supervisors'),
 });
 const dispatchToProps = dispatch => ({ dispatch });
 

--- a/src/reducers/__tests__/literature.test.js
+++ b/src/reducers/__tests__/literature.test.js
@@ -26,6 +26,7 @@ describe('literature reducer', () => {
       loadingAuthors: false,
       errorAuthors: {},
       authors: [],
+      supervisors: [],
     });
     expect(state).toEqual(expected);
   });
@@ -121,9 +122,15 @@ describe('literature reducer', () => {
         full_name: 'Jessica Jones',
       },
     ];
+    const supervisors = [
+      {
+        full_name: 'Kapustin, Anton',
+      },
+    ];
     const payload = {
       metadata: {
         authors,
+        supervisors,
       },
     };
     const state = reducer(Map(), {
@@ -133,6 +140,7 @@ describe('literature reducer', () => {
     const expected = fromJS({
       loadingAuthors: false,
       authors,
+      supervisors,
       errorAuthors: {},
     });
     expect(state).toEqual(expected);
@@ -147,6 +155,7 @@ describe('literature reducer', () => {
       loadingAuthors: false,
       errorAuthors: { message: 'error' },
       authors: [],
+      supervisors: [],
     });
     expect(state).toEqual(expected);
   });

--- a/src/reducers/literature.js
+++ b/src/reducers/literature.js
@@ -22,6 +22,7 @@ export const initialState = fromJS({
   loadingAuthors: false,
   errorAuthors: {},
   authors: [],
+  supervisors: [],
 });
 
 const literatureReducer = (state = initialState, action) => {
@@ -53,12 +54,14 @@ const literatureReducer = (state = initialState, action) => {
       return state
         .set('loadingAuthors', false)
         .set('authors', fromJS(action.payload.metadata.authors))
+        .set('supervisors', fromJS(action.payload.metadata.supervisors))
         .set('errorAuthors', initialState.get('errorAuthors'));
     case LITERATURE_AUTHORS_ERROR:
       return state
         .set('loadingAuthors', false)
         .set('errorAuthors', fromJS(action.payload))
-        .set('authors', initialState.get('authors'));
+        .set('authors', initialState.get('authors'))
+        .set('supervisors', initialState.get('supervisors'));
     default:
       return state;
   }


### PR DESCRIPTION
User-story: [INSPIR-986](https://its.cern.ch/jira/browse/INSPIR-986)
Screenshot:
![screenshot from 2018-07-31 18-49-42](https://user-images.githubusercontent.com/11242410/43474257-a461a9e8-94f2-11e8-874a-e912affcbc1d.png)

Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>