### PR TITLE
literature: display supervisors if more than 1 supervisor is passed

### DIFF
--- a/src/literature/components/AuthorList.jsx
+++ b/src/literature/components/AuthorList.jsx
@@ -26,6 +26,11 @@ class AuthorList extends Component {
     this.setState({ modalVisible: false });
   }
 
+  getSupervisorsLabel() {
+    const { authors } = this.props;
+    return authors.size === 1 ? 'Supervisor' : 'Supervisors';
+  }
+
   renderShowAllOrEtAl() {
     const { enableShowAll, authors } = this.props;
     if (enableShowAll) {
@@ -50,7 +55,7 @@ class AuthorList extends Component {
     } = this.props;
     return (
       <InlineList
-        label={forSupervisors ? 'Supervisor(s)' : null}
+        label={forSupervisors ? this.getSupervisorsLabel() : null}
         wrapperClassName={wrapperClassName}
         items={authorsToDisplay}
         suffix={

--- a/src/literature/components/__tests__/AuthorList.test.jsx
+++ b/src/literature/components/__tests__/AuthorList.test.jsx
@@ -137,19 +137,34 @@ describe('AuthorList', () => {
     ).toMatchSnapshot();
   });
 
-  it('prefixes `Supervisor(s)` when supervisors are passed', () => {
+  it('prefixes `Supervisor` when 1 supervisor is passed', () => {
     const supervisors = fromJS([
       {
         full_name: 'Test, Guy 1',
       },
     ]);
     const wrapper = shallow(
-      <AuthorList
-        label="Supervisor(s)"
-        authors={supervisors}
-        recordId={12345}
-        forSupervisors
-      />
+      <AuthorList authors={supervisors} recordId={12345} forSupervisors />
+    );
+    expect(
+      wrapper
+        .find(InlineList)
+        .first()
+        .dive()
+    ).toMatchSnapshot();
+  });
+
+  it('prefixes `Supervisor` when 2 or more supervisors are passed', () => {
+    const supervisors = fromJS([
+      {
+        full_name: 'Test, Guy 1',
+      },
+      {
+        full_name: 'Test, Guy 2',
+      },
+    ]);
+    const wrapper = shallow(
+      <AuthorList authors={supervisors} recordId={12345} forSupervisors />
     );
     expect(
       wrapper
@@ -165,9 +180,7 @@ describe('AuthorList', () => {
         full_name: 'Test, Guy 1',
       },
     ]);
-    const wrapper = shallow(
-      <AuthorList label="Supervisor(s)" authors={authors} recordId={12345} />
-    );
+    const wrapper = shallow(<AuthorList authors={authors} recordId={12345} />);
     expect(
       wrapper
         .find(Modal)
@@ -183,12 +196,7 @@ describe('AuthorList', () => {
       },
     ]);
     const wrapper = shallow(
-      <AuthorList
-        label="Supervisor(s)"
-        authors={supervisors}
-        recordId={12345}
-        forSupervisors
-      />
+      <AuthorList authors={supervisors} recordId={12345} forSupervisors />
     );
     expect(
       wrapper

--- a/src/literature/components/__tests__/__snapshots__/AuthorList.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/AuthorList.test.jsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AuthorList prefixes \`Supervisor(s)\` when supervisors are passed 1`] = `
+exports[`AuthorList prefixes \`Supervisor\` when 1 supervisor is passed 1`] = `
 <div
   className="__InlineList__"
 >
   <span>
-    Supervisor(s)
+    Supervisor
     : 
   </span>
   <ul
@@ -18,6 +18,45 @@ exports[`AuthorList prefixes \`Supervisor(s)\` when supervisors are passed 1`] =
         author={
           Immutable.Map {
             full_name: "Test, Guy 1",
+          }
+        }
+        recordId={12345}
+      />
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`AuthorList prefixes \`Supervisor\` when 2 or more supervisors are passed 1`] = `
+<div
+  className="__InlineList__"
+>
+  <span>
+    Supervisors
+    : 
+  </span>
+  <ul
+    className="separate-items-with-semicolon"
+  >
+    <li
+      key="Test, Guy 1"
+    >
+      <AuthorLink
+        author={
+          Immutable.Map {
+            full_name: "Test, Guy 1",
+          }
+        }
+        recordId={12345}
+      />
+    </li>
+    <li
+      key="Test, Guy 2"
+    >
+      <AuthorLink
+        author={
+          Immutable.Map {
+            full_name: "Test, Guy 2",
           }
         }
         recordId={12345}
@@ -466,7 +505,7 @@ exports[`AuthorList should show \`supervisors\` in modal title if supervisors ar
         },
       ]
     }
-    label="Supervisor(s)"
+    label="Supervisor"
     renderItem={[Function]}
     separateItems={true}
     separateItemsClassName="separate-items-with-semicolon"


### PR DESCRIPTION
user-story: [INSPIR-1135](https://its.cern.ch/jira/browse/INSPIR-1135)
Screenshot
![screenshot from 2018-08-07 13-45-38](https://user-images.githubusercontent.com/11242410/43774236-c49d6368-9a48-11e8-9cb9-eac8d4adc9fd.png)

Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>