### PR TITLE
holdingpen: fix ui for exceptions dashboard

### DIFF
--- a/src/holdingpen/components/ExceptionsDashboard.jsx
+++ b/src/holdingpen/components/ExceptionsDashboard.jsx
@@ -50,8 +50,11 @@ class ExceptionsDashboard extends Component {
         </div>
 
         <Row type="flex" justify="space-around">
-          <Col>
-            <ExceptionsTable exceptions={this.props.exceptions} />
+          <Col span={20} justify="center" align="middle">
+            <ExceptionsTable
+              exceptions={this.props.exceptions}
+              loading={this.props.loading}
+            />
           </Col>
         </Row>
       </div>
@@ -67,6 +70,7 @@ ExceptionsDashboard.propTypes = {
       recid: PropTypes.number,
     })
   ).isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 export default ExceptionsDashboard;

--- a/src/holdingpen/components/ExceptionsTable.jsx
+++ b/src/holdingpen/components/ExceptionsTable.jsx
@@ -162,10 +162,12 @@ class ExceptionsTable extends Component {
         columns={columns}
         dataSource={this.state.filteredExceptions}
         rowKey="recid"
+        rowClassName="exceptions-table-row"
         pagination={{ pageSize: 25 }}
         onChange={this.onSelectedCollectionsChange}
         expandedRowRender={record => <pre>{record.error}</pre>}
         bordered
+        loading
       />
     );
   }
@@ -180,6 +182,7 @@ ExceptionsTable.propTypes = {
       recid: PropTypes.number,
     })
   ).isRequired,
+  loading: PropTypes.bool.isRequired,
   /* eslint-disable react/no-unused-prop-types */
 };
 

--- a/src/holdingpen/components/ExceptionsTable.scss
+++ b/src/holdingpen/components/ExceptionsTable.scss
@@ -1,15 +1,8 @@
 .__ExceptionsTable__ {
-  width: 1400px;
-}
-
-@media (max-width: 1400px) {
-  .__ExceptionsTable__ {
-    width: 1200px;
+  pre {
+    white-space: pre-wrap;
   }
-}
-
-@media (max-width: 1200px) {
-  .__ExceptionsTable__ {
-    width: 800px;
+  .exceptions-table-row {
+    background: white;
   }
 }

--- a/src/holdingpen/components/__tests__/ExceptionsDashboard.test.jsx
+++ b/src/holdingpen/components/__tests__/ExceptionsDashboard.test.jsx
@@ -26,7 +26,10 @@ describe('ExceptionsDashboard', () => {
         recid: 1635467,
       },
     ];
-    const wrapper = shallow(<ExceptionsDashboard exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsDashboard exceptions={exceptions} loading={loading} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/holdingpen/components/__tests__/ExceptionsTable.test.jsx
+++ b/src/holdingpen/components/__tests__/ExceptionsTable.test.jsx
@@ -21,7 +21,10 @@ describe('ExceptionsTable', () => {
         recid: 1635467,
       },
     ];
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -43,8 +46,11 @@ describe('ExceptionsTable', () => {
         recid: 1635467,
       },
     ];
+    const loading = false;
     const searchText = 'MyError';
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     wrapper.instance().onErrorSearch(searchText);
     wrapper.update();
     expect(wrapper).toMatchSnapshot();
@@ -69,7 +75,10 @@ describe('ExceptionsTable', () => {
       },
     ];
     const searchText = 'Thing';
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     wrapper.instance().onErrorSearch(searchText);
     wrapper.update();
     expect(wrapper).toMatchSnapshot();
@@ -94,7 +103,10 @@ describe('ExceptionsTable', () => {
       },
     ];
     const searchText = '';
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     wrapper.instance().onErrorSearch(searchText);
     wrapper.update();
     expect(wrapper).toMatchSnapshot();
@@ -119,7 +131,10 @@ describe('ExceptionsTable', () => {
       },
     ];
     const recidText = '1234';
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     wrapper.instance().onRecidSearch(recidText);
     wrapper.update();
     expect(wrapper).toMatchSnapshot();
@@ -144,7 +159,10 @@ describe('ExceptionsTable', () => {
       },
     ];
     const recidText = '12345';
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     wrapper.instance().onRecidSearch(recidText);
     wrapper.update();
     expect(wrapper).toMatchSnapshot();
@@ -169,7 +187,10 @@ describe('ExceptionsTable', () => {
       },
     ];
     const recidText = '';
-    const wrapper = shallow(<ExceptionsTable exceptions={exceptions} />);
+    const loading = false;
+    const wrapper = shallow(
+      <ExceptionsTable exceptions={exceptions} loading={loading} />
+    );
     wrapper.instance().onRecidSearch(recidText);
     wrapper.update();
     expect(wrapper).toMatchSnapshot();

--- a/src/holdingpen/components/__tests__/__snapshots__/ExceptionsDashboard.test.jsx.snap
+++ b/src/holdingpen/components/__tests__/__snapshots__/ExceptionsDashboard.test.jsx.snap
@@ -38,7 +38,11 @@ exports[`ExceptionsDashboard renders with all props set 1`] = `
     justify="space-around"
     type="flex"
   >
-    <Col>
+    <Col
+      align="middle"
+      justify="center"
+      span={20}
+    >
       <ExceptionsTable
         exceptions={
           Array [
@@ -64,6 +68,7 @@ exports[`ExceptionsDashboard renders with all props set 1`] = `
             },
           ]
         }
+        loading={false}
       />
     </Col>
   </Row>

--- a/src/holdingpen/components/__tests__/__snapshots__/ExceptionsTable.test.jsx.snap
+++ b/src/holdingpen/components/__tests__/__snapshots__/ExceptionsTable.test.jsx.snap
@@ -75,7 +75,7 @@ exports[`ExceptionsTable renders all exceptions on clear error search 1`] = `
   }
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -83,6 +83,7 @@ exports[`ExceptionsTable renders all exceptions on clear error search 1`] = `
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}
@@ -166,7 +167,7 @@ exports[`ExceptionsTable renders all exceptions on clear recid search 1`] = `
   }
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -174,6 +175,7 @@ exports[`ExceptionsTable renders all exceptions on clear recid search 1`] = `
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}
@@ -252,7 +254,7 @@ exports[`ExceptionsTable renders filtered results on error search 1`] = `
   }
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -260,6 +262,7 @@ exports[`ExceptionsTable renders filtered results on error search 1`] = `
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}
@@ -325,7 +328,7 @@ exports[`ExceptionsTable renders no results on error search if nothing matches 1
   dataSource={Array []}
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -333,6 +336,7 @@ exports[`ExceptionsTable renders no results on error search if nothing matches 1
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}
@@ -398,7 +402,7 @@ exports[`ExceptionsTable renders no results on recid search if there is no exact
   dataSource={Array []}
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -406,6 +410,7 @@ exports[`ExceptionsTable renders no results on recid search if there is no exact
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}
@@ -479,7 +484,7 @@ exports[`ExceptionsTable renders single exception on recid search if there is ex
   }
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -487,6 +492,7 @@ exports[`ExceptionsTable renders single exception on recid search if there is ex
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}
@@ -570,7 +576,7 @@ exports[`ExceptionsTable renders with exceptions 1`] = `
   }
   expandedRowRender={[Function]}
   indentSize={20}
-  loading={false}
+  loading={true}
   locale={Object {}}
   pagination={
     Object {
@@ -578,6 +584,7 @@ exports[`ExceptionsTable renders with exceptions 1`] = `
     }
   }
   prefixCls="ant-table"
+  rowClassName="exceptions-table-row"
   rowKey="recid"
   rowSelection={null}
   showHeader={true}

--- a/src/holdingpen/containers/ExceptionsPage.jsx
+++ b/src/holdingpen/containers/ExceptionsPage.jsx
@@ -12,17 +12,24 @@ class ExceptionsPage extends Component {
   }
 
   render() {
-    return <ExceptionsDashboard exceptions={this.props.exceptions} />;
+    return (
+      <ExceptionsDashboard
+        exceptions={this.props.exceptions}
+        loading={this.props.loading}
+      />
+    );
   }
 }
 
 ExceptionsPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
   exceptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   exceptions: state.exceptions.get('data'),
+  loading: state.exceptions.get('loading'),
 });
 const dispatchToProps = dispatch => ({ dispatch });
 

--- a/src/holdingpen/containers/__tests__/ExceptionsPage.test.jsx
+++ b/src/holdingpen/containers/__tests__/ExceptionsPage.test.jsx
@@ -16,6 +16,7 @@ describe('ExceptionsPage', () => {
             recid: 123456,
           },
         ],
+        loading: false,
       }),
     });
 
@@ -35,6 +36,7 @@ describe('ExceptionsPage', () => {
             recid: 123456,
           },
         ],
+        loading: false,
       }),
     });
     mount(<ExceptionsPage store={store} />);

--- a/src/holdingpen/containers/__tests__/__snapshots__/ExceptionsPage.test.jsx.snap
+++ b/src/holdingpen/containers/__tests__/__snapshots__/ExceptionsPage.test.jsx.snap
@@ -11,5 +11,6 @@ exports[`ExceptionsPage renders initial state 1`] = `
       },
     ]
   }
+  loading={false}
 />
 `;


### PR DESCRIPTION
User-story: [INSPIR-1203](https://its.cern.ch/jira/browse/INSPIR-1203)

Fixes:
i) the width of the table when the rows are expanded
ii) the color of the rows in the table
iii) the loading icon is displayed when the exceptions are loading

Screenshot:
![screenshot from 2018-08-17 17-16-09](https://user-images.githubusercontent.com/11242410/44274559-b996a900-a242-11e8-95e8-a051975ce996.png)
![screenshot from 2018-08-17 17-16-26](https://user-images.githubusercontent.com/11242410/44274563-bb606c80-a242-11e8-8a85-9f44588f9df9.png)


Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>