### PR TITLE
fix CitationList pagination current page

### DIFF
--- a/src/common/components/ClientPaginatedList.jsx
+++ b/src/common/components/ClientPaginatedList.jsx
@@ -6,7 +6,8 @@ import ListWithPagination from './ListWithPagination';
 class ClientPaginatedList extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     const { items, pageSize } = nextProps;
-    const pageItems = ClientPaginatedList.getPageItems(items, 1, pageSize);
+    const { page } = prevState;
+    const pageItems = ClientPaginatedList.getPageItems(items, page, pageSize);
     return {
       ...prevState,
       pageItems,
@@ -22,9 +23,11 @@ class ClientPaginatedList extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
-
     this.onPageChange = this.onPageChange.bind(this);
+
+    this.state = {
+      page: 1,
+    };
   }
 
   onPageChange(page) {
@@ -32,12 +35,13 @@ class ClientPaginatedList extends Component {
     const pageItems = ClientPaginatedList.getPageItems(items, page, pageSize);
     this.setState({
       pageItems,
+      page,
     });
   }
 
   render() {
     const { renderItem, pageSize, title, items, loading } = this.props;
-    const { pageItems, total } = this.state;
+    const { pageItems, total, page } = this.state;
     return (
       items.size > 0 && (
         <ListWithPagination
@@ -45,6 +49,7 @@ class ClientPaginatedList extends Component {
           renderItem={renderItem}
           pageItems={pageItems}
           pageSize={pageSize}
+          page={page}
           onPageChange={this.onPageChange}
           total={total}
           loading={loading}

--- a/src/common/components/ListWithPagination.jsx
+++ b/src/common/components/ListWithPagination.jsx
@@ -13,26 +13,12 @@ class ListWithPagination extends Component {
     return `${range[0]}-${range[1]} of ${total}`;
   }
 
-  constructor(props) {
-    super(props);
-    this.onPageChange = this.onPageChange.bind(this);
-    this.state = {
-      page: 1,
-    };
-  }
-
-  onPageChange(page) {
-    this.setState({ page });
-    this.props.onPageChange(page);
-  }
-
   renderPagination() {
-    const { pageSize, loading, total } = this.props;
-    const { page } = this.state;
+    const { pageSize, loading, total, page, onPageChange } = this.props;
     return (
       <Pagination
         current={page}
-        onChange={this.onPageChange}
+        onChange={onPageChange}
         total={total}
         pageSize={pageSize}
         loading={loading}
@@ -42,8 +28,7 @@ class ListWithPagination extends Component {
   }
 
   render() {
-    const { renderItem, title, pageItems } = this.props;
-    const { page } = this.state;
+    const { renderItem, title, pageItems, page } = this.props;
     return (
       <List header={title} footer={this.renderPagination()}>
         {pageItems.map((item, index) => renderItem(item, index, page))}
@@ -58,6 +43,7 @@ ListWithPagination.propTypes = {
   renderItem: PropTypes.func.isRequired,
   onPageChange: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
+  page: PropTypes.number.isRequired,
   title: PropTypes.node,
   loading: PropTypes.bool,
 };

--- a/src/common/components/__tests__/ListWithPagination.test.jsx
+++ b/src/common/components/__tests__/ListWithPagination.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Range } from 'immutable';
-import { List } from 'antd';
+import { List, Pagination } from 'antd';
 
 import ListWithPagination from '../ListWithPagination';
 
@@ -12,6 +12,7 @@ describe('ListWithPagination', () => {
       <ListWithPagination
         pageItems={pageItems}
         pageSize={50}
+        page={1}
         total={100}
         onPageChange={jest.fn()}
         renderItem={item => <List.Item key={item}>{item}</List.Item>}
@@ -26,6 +27,7 @@ describe('ListWithPagination', () => {
       <ListWithPagination
         pageItems={pageItems}
         pageSize={25}
+        page={2}
         total={100}
         onPageChange={jest.fn()}
         renderItem={item => <List.Item key={item}>{item}</List.Item>}
@@ -36,23 +38,20 @@ describe('ListWithPagination', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('sets new page state and calls props.onPageChange on page change', () => {
+  it('sets props.onPageChange to Pagination.onChange', () => {
     const pageItems = Range(1, 25).toList();
-    const onPageChangeProp = jest.fn();
+    const onPageChange = jest.fn();
     const wrapper = shallow(
       <ListWithPagination
         pageItems={pageItems}
         pageSize={25}
+        page={1}
         total={100}
-        onPageChange={onPageChangeProp}
+        onPageChange={onPageChange}
         renderItem={item => <List.Item key={item}>{item}</List.Item>}
       />
-    );
-    const page = 2;
-    wrapper.instance().onPageChange(page);
-    wrapper.update();
-    expect(wrapper.state('page')).toBe(page);
-    expect(onPageChangeProp).toHaveBeenCalledWith(page);
+    ).dive();
+    expect(wrapper.find(Pagination)).toHaveProp('onChange', onPageChange);
   });
 
   describe('getPaginationRangeInfo', () => {

--- a/src/common/components/__tests__/__snapshots__/ClientPaginatedList.test.jsx.snap
+++ b/src/common/components/__tests__/__snapshots__/ClientPaginatedList.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`ClientPaginatedList renders as loading if set 1`] = `
 <ListWithPagination
   loading={true}
   onPageChange={[Function]}
+  page={1}
   pageItems={
     Immutable.List [
       1,
@@ -31,6 +32,7 @@ exports[`ClientPaginatedList renders first page 1`] = `
 <ListWithPagination
   loading={false}
   onPageChange={[Function]}
+  page={1}
   pageItems={
     Immutable.List [
       1,
@@ -71,6 +73,7 @@ exports[`ClientPaginatedList renders first page with custom pageSize 1`] = `
 <ListWithPagination
   loading={false}
   onPageChange={[Function]}
+  page={1}
   pageItems={
     Immutable.List [
       1,
@@ -96,6 +99,7 @@ exports[`ClientPaginatedList renders the new page on page change 1`] = `
 <ListWithPagination
   loading={false}
   onPageChange={[Function]}
+  page={2}
   pageItems={
     Immutable.List [
       11,

--- a/src/common/components/__tests__/__snapshots__/ListWithPagination.test.jsx.snap
+++ b/src/common/components/__tests__/__snapshots__/ListWithPagination.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`ListWithPagination renders with all props 1`] = `
   dataSource={Array []}
   footer={
     <Pagination
-      current={1}
+      current={2}
       loading={true}
       onChange={[Function]}
       pageSize={25}

--- a/src/common/containers/CitationList.jsx
+++ b/src/common/containers/CitationList.jsx
@@ -19,7 +19,9 @@ class CitationList extends Component {
 
   constructor(props) {
     super(props);
-
+    this.state = {
+      page: 1,
+    };
     this.onPageChange = this.onPageChange.bind(this);
   }
 
@@ -32,11 +34,13 @@ class CitationList extends Component {
 
   onPageChange(page) {
     const { pidType, recordId, dispatch } = this.props;
+    this.setState({ page });
     dispatch(fetchCitations(pidType, recordId, { page, pageSize: PAGE_SIZE }));
   }
 
   render() {
     const { loading, total, citations } = this.props;
+    const { page } = this.state;
     return (
       <ContentBox title={`Citations (${total})`} loading={loading}>
         {total > 0 && (
@@ -46,6 +50,7 @@ class CitationList extends Component {
             onPageChange={this.onPageChange}
             total={total}
             loading={loading}
+            page={page}
             pageSize={PAGE_SIZE}
           />
         )}

--- a/src/common/containers/__tests__/CitationList.test.jsx
+++ b/src/common/containers/__tests__/CitationList.test.jsx
@@ -40,7 +40,7 @@ describe('CitationList', () => {
     });
   });
 
-  it('calls fetchCitations on page change', () => {
+  it('calls fetchCitations and sets page state on page change', () => {
     const store = getStore();
     const wrapper = shallow(
       <CitationList pidType="test" recordId={123} store={store} />
@@ -51,6 +51,7 @@ describe('CitationList', () => {
       page,
       pageSize: PAGE_SIZE,
     });
+    expect(wrapper.state('page')).toEqual(page);
   });
 
   it('does not render if total <= 0', () => {

--- a/src/common/containers/__tests__/__snapshots__/CitationList.test.jsx.snap
+++ b/src/common/containers/__tests__/__snapshots__/CitationList.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`CitationList renders with state from store 1`] = `
   <ListWithPagination
     loading={false}
     onPageChange={[Function]}
+    page={1}
     pageItems={
       Immutable.List [
         Immutable.Map {


### PR DESCRIPTION
Current page was always showing as the first even though data was
changing, because ListWithPagination was the one with page=1 initial
state and it was getting unmounted whenever CitationList is rerendered
with a new page.

Now keeping track of the current page responsibility pulled out to
components that are using ListWithPagination