### PR TITLE
remove logic related to splitting collaborations into 2 lists

### DIFF
--- a/src/literature/components/CollaborationList.jsx
+++ b/src/literature/components/CollaborationList.jsx
@@ -5,34 +5,20 @@ import { List } from 'immutable';
 import CollaborationLink from './CollaborationLink';
 import InlineList from '../../common/components/InlineList';
 
-const REGEX_COLLABORATIONS_WITH_SUFFIX = /(group|groups|force|consortium|team)$/i;
-
 class CollaborationList extends Component {
-  static collaborationMatchSuffix(item) {
-    return item.get('value').match(REGEX_COLLABORATIONS_WITH_SUFFIX);
-  }
-
   render() {
-    const { collaborations } = this.props;
-    const collaborationsWithSuffix = collaborations.filter(
-      CollaborationList.collaborationMatchSuffix
-    );
-    const collaborationsWithoutSuffix = collaborations.filterNot(
-      CollaborationList.collaborationMatchSuffix
-    );
+    const { collaborations, collaborationsWithSuffix } = this.props;
 
     return (
       <Fragment>
         <InlineList
           wrapperClassName="di"
           separateItemsClassName="separate-items-with-and"
-          items={collaborationsWithoutSuffix}
+          items={collaborations}
           suffix={
-            collaborationsWithoutSuffix.size > 0 && (
+            collaborations.size > 0 && (
               <span className="pr1">
-                {collaborationsWithoutSuffix.size > 1
-                  ? ' Collaborations'
-                  : ' Collaboration'}
+                {collaborations.size > 1 ? ' Collaborations' : ' Collaboration'}
               </span>
             )
           }
@@ -56,10 +42,12 @@ class CollaborationList extends Component {
 
 CollaborationList.propTypes = {
   collaborations: PropTypes.instanceOf(List),
+  collaborationsWithSuffix: PropTypes.instanceOf(List),
 };
 
 CollaborationList.defaultProps = {
   collaborations: List(),
+  collaborationsWithSuffix: List(),
 };
 
 export default CollaborationList;

--- a/src/literature/components/LiteratureItem.jsx
+++ b/src/literature/components/LiteratureItem.jsx
@@ -35,6 +35,7 @@ class LiteratureItem extends Component {
     const eprints = metadata.get('arxiv_eprints');
     const dois = metadata.get('dois');
     const collaborations = metadata.get('collaborations');
+    const collaborationsWithSuffix = metadata.get('collaborations_with_suffix');
     const reportNumbers = metadata.get('report_numbers');
     const abstract = metadata.getIn(['abstracts', 0, 'value']);
 
@@ -66,7 +67,10 @@ class LiteratureItem extends Component {
         </Link>
         <div className="mt2">
           <div>
-            <CollaborationList collaborations={collaborations} />
+            <CollaborationList
+              collaborations={collaborations}
+              collaborationsWithSuffix={collaborationsWithSuffix}
+            />
             <AuthorList
               authorCount={authorCount}
               recordId={recordId}

--- a/src/literature/components/__tests__/CollaborationList.test.jsx
+++ b/src/literature/components/__tests__/CollaborationList.test.jsx
@@ -25,24 +25,29 @@ describe('CollaborationList', () => {
   });
 
   it('renders with collaborations with and without suffix', () => {
-    const collaborations = fromJS([
-      { value: 'Alias Investigations' },
-      { value: 'Nelson and Murdock' },
-      { value: 'Defenders Group and Avengers' },
-      { value: 'Defenders Task Force and Avengers' },
+    const collaborationsWithSuffix = fromJS([
       { value: 'Avangers Groups' },
       { value: 'Avangers Task Force' },
       { value: 'Avangers Consortium' },
       { value: 'Avangers Team' },
     ]);
+    const collaborations = fromJS([
+      { value: 'Alias Investigations' },
+      { value: 'Nelson and Murdock' },
+      { value: 'Defenders Group and Avengers' },
+      { value: 'Defenders Task Force and Avengers' },
+    ]);
     const wrapper = shallow(
-      <CollaborationList collaborations={collaborations} />
+      <CollaborationList
+        collaborations={collaborations}
+        collaborationsWithSuffix={collaborationsWithSuffix}
+      />
     );
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders with collaborations with suffix', () => {
-    const collaborations = fromJS([
+    const collaborationsWithSuffix = fromJS([
       { value: 'Avangers Groups' },
       { value: 'Avangers Group' },
       { value: 'Avangers Task Force' },
@@ -50,7 +55,7 @@ describe('CollaborationList', () => {
       { value: 'Avangers Team' },
     ]);
     const wrapper = shallow(
-      <CollaborationList collaborations={collaborations} />
+      <CollaborationList collaborationsWithSuffix={collaborationsWithSuffix} />
     );
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/literature/components/__tests__/LiteratureItem.test.jsx
+++ b/src/literature/components/__tests__/LiteratureItem.test.jsx
@@ -14,10 +14,12 @@ describe('LiteratureItem', () => {
       arxiv_eprints: [{ value: '1234567890' }],
       control_number: 12345,
       citation_count: 1,
-      publicaion_info: [{ journal_title: 'Test Jornal' }],
+      publication_info: [{ journal_title: 'Test Jornal' }],
       dois: [{ value: '12345679.1234.123' }],
       report_numbers: [{ value: 'ABCD-AB-CD-1234-123' }],
       abstract: [{ value: 'Test Abstract' }],
+      collaborations: [{ value: 'CMS' }],
+      collaborations_with_suffix: [{ value: 'CMS Group' }],
     });
     const wrapper = shallow(<LiteratureItem metadata={metadata} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
+++ b/src/literature/components/__tests__/__snapshots__/LiteratureItem.test.jsx.snap
@@ -46,6 +46,10 @@ exports[`LiteratureItem does not arxiv pdf download action if there is no eprint
           Immutable.List [
           ]
         }
+        collaborationsWithSuffix={
+          Immutable.List [
+          ]
+        }
       />
       <AuthorList
         authors={
@@ -130,6 +134,10 @@ exports[`LiteratureItem renders 0 citations and 0 references if they do not exis
     <div>
       <CollaborationList
         collaborations={
+          Immutable.List [
+          ]
+        }
+        collaborationsWithSuffix={
           Immutable.List [
           ]
         }
@@ -223,6 +231,16 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
       <CollaborationList
         collaborations={
           Immutable.List [
+            Immutable.Map {
+              value: "CMS",
+            },
+          ]
+        }
+        collaborationsWithSuffix={
+          Immutable.List [
+            Immutable.Map {
+              value: "CMS Group",
+            },
           ]
         }
       />
@@ -236,7 +254,7 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
         }
         enableShowAll={false}
         forSupervisors={false}
-        limit={5}
+        limit={1}
         recordId={12345}
         total={-1}
         wrapperClassName={null}
@@ -251,7 +269,13 @@ exports[`LiteratureItem renders with all props set, including sub props 1`] = `
   >
     <PublicationInfoList
       labeled={true}
-      publicationInfo={null}
+      publicationInfo={
+        Immutable.List [
+          Immutable.Map {
+            journal_title: "Test Jornal",
+          },
+        ]
+      }
     />
     <ArxivEprintList
       eprints={

--- a/src/literature/containers/DetailPage/DetailPage.jsx
+++ b/src/literature/containers/DetailPage/DetailPage.jsx
@@ -77,6 +77,7 @@ class DetailPage extends Component {
     const abstract = metadata.getIn(['abstracts', 0]);
     const arxivId = metadata.getIn(['arxiv_eprints', 0, 'value']);
     const collaborations = metadata.get('collaborations');
+    const collaborationsWithSuffix = metadata.get('collaborations_with_suffix');
 
     const keywords = metadata.get('keywords');
     const authorCount = metadata.get('author_count');
@@ -97,7 +98,10 @@ class DetailPage extends Component {
               <Latex>{title}</Latex>
             </h2>
             <div>
-              <CollaborationList collaborations={collaborations} />
+              <CollaborationList
+                collaborations={collaborations}
+                collaborationsWithSuffix={collaborationsWithSuffix}
+              />
               <AuthorList
                 total={authorCount}
                 recordId={recordId}


### PR DESCRIPTION
Removed the logic related to splitting the collaborations into 2 lists by suffix.
Added the collaborations_with_suffix list and displayed it properly.