### PR TITLE
“Tools” menu should not show curator tools to non-curators

### DIFF
--- a/src/common/layouts/Header/Header.jsx
+++ b/src/common/layouts/Header/Header.jsx
@@ -1,22 +1,22 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Layout, Row, Col } from 'antd';
 import PropTypes from 'prop-types';
+import { Set } from 'immutable';
 
 import SearchBoxContainer from './../../containers/SearchBoxContainer';
 import DropdownMenu from '../../components/DropdownMenu';
 import './Header.scss';
 import logo from './logo.svg';
 import LoginOrUserDropdownContainer from '../../containers/LoginOrUserDropdownContainer';
+import { doSetsHaveCommonItem } from '../../utils';
 
-const TOOL_LINKS = [
+const ONLY_SUPER_USERS_AND_CATALOGERS = Set(['superuser', 'cataloger']);
+
+const UNAUTHORIZED_TOOL_LINKS = [
   {
-    to: '/holdingpen/dashboard',
-    display: 'Holdingpen',
-  },
-  {
-    href: '//inspirehep.net/textmining',
+    href: '//inspirehep.net/textmining/',
     display: 'Reference extractor',
   },
   {
@@ -29,46 +29,70 @@ const TOOL_LINKS = [
   },
 ];
 
-const Header = props => (
-  <Layout.Header className="__Header__">
-    <Row type="flex" align="middle" gutter={16}>
-      <Col lg={5}>
-        <Link to="/">
-          <img src={logo} alt="INSPIRE Labs" />
-        </Link>
-      </Col>
-      <Col lg={13} xl={14}>
-        {props.shouldDisplaySearchBox && <SearchBoxContainer />}
-      </Col>
-      <Col lg={6} xl={5}>
-        <Row type="flex" justify="end">
-          <Col className="nav-item-container">
-            <DropdownMenu
-              title="Tools"
-              titleClassName="nav-item"
-              items={TOOL_LINKS}
-            />
-          </Col>
-          <Col className="nav-item-container">
-            <Link className="nav-item" to="/submissions/authors">
-              Submit
+const ALL_TOOL_LINKS = [
+  {
+    href: '/holdingpen',
+    display: 'Holdingpen',
+  },
+  ...UNAUTHORIZED_TOOL_LINKS,
+];
+
+class Header extends Component {
+  getToolLinksForUser() {
+    const { userRoles } = this.props;
+
+    if (doSetsHaveCommonItem(userRoles, ONLY_SUPER_USERS_AND_CATALOGERS)) {
+      return ALL_TOOL_LINKS;
+    }
+    return UNAUTHORIZED_TOOL_LINKS;
+  }
+
+  render() {
+    const { shouldDisplaySearchBox } = this.props;
+
+    return (
+      <Layout.Header className="__Header__">
+        <Row type="flex" align="middle" gutter={16}>
+          <Col lg={5}>
+            <Link to="/">
+              <img src={logo} alt="INSPIRE Labs" />
             </Link>
           </Col>
-          <Col className="nav-item-container">
-            <LoginOrUserDropdownContainer />
+          <Col lg={13} xl={14}>
+            {shouldDisplaySearchBox && <SearchBoxContainer />}
+          </Col>
+          <Col lg={6} xl={5}>
+            <Row type="flex" justify="end">
+              <Col className="nav-item-container">
+                <DropdownMenu
+                  title="Tools"
+                  titleClassName="nav-item"
+                  items={this.getToolLinksForUser()}
+                />
+              </Col>
+              <Col className="nav-item-container">
+                <Link className="nav-item" to="/submissions/authors">
+                  Submit
+                </Link>
+              </Col>
+              <Col className="nav-item-container">
+                <LoginOrUserDropdownContainer />
+              </Col>
+            </Row>
           </Col>
         </Row>
-      </Col>
-    </Row>
-  </Layout.Header>
-);
-
+      </Layout.Header>
+    );
+  }
+}
 Header.propTypes = {
   shouldDisplaySearchBox: PropTypes.bool.isRequired,
+  userRoles: PropTypes.instanceOf(Set).isRequired,
 };
 
 const stateToProps = state => ({
   shouldDisplaySearchBox: state.router.location.pathname !== '/',
+  userRoles: Set(state.user.getIn(['data', 'roles'])),
 });
 
 export default connect(stateToProps)(Header);

--- a/src/common/layouts/Header/__tests__/Header.test.jsx
+++ b/src/common/layouts/Header/__tests__/Header.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { fromJS } from 'immutable';
 
 import { getStoreWithState } from '../../../../fixtures/store';
 import Header from '../Header';
@@ -26,6 +27,36 @@ describe('Header', () => {
       },
     });
     const wrapper = shallow(<Header store={store} />).dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('does not show authorized tool links if logged in user is not superuser nor cataloger', () => {
+    const store = getStoreWithState({
+      user: fromJS({
+        loggedIn: true,
+        data: {
+          roles: ['betauser'],
+        },
+      }),
+    });
+
+    const wrapper = shallow(<Header store={store} />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('shows authorized tool links if logged in user is cataloger', () => {
+    const store = getStoreWithState({
+      user: fromJS({
+        loggedIn: true,
+        data: {
+          roles: ['superuser'],
+        },
+      }),
+    });
+
+    const wrapper = shallow(<Header store={store} />).dive();
+
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/common/layouts/Header/__tests__/__snapshots__/Header.test.jsx.snap
+++ b/src/common/layouts/Header/__tests__/__snapshots__/Header.test.jsx.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Header does not show authorized tool links if logged in user is not superuser nor cataloger 1`] = `
+<Adapter
+  className="__Header__"
+>
+  <Row
+    align="middle"
+    gutter={16}
+    type="flex"
+  >
+    <Col
+      lg={5}
+    >
+      <Link
+        replace={false}
+        to="/"
+      >
+        <img
+          alt="INSPIRE Labs"
+          src="logo.svg"
+        />
+      </Link>
+    </Col>
+    <Col
+      lg={13}
+      xl={14}
+    >
+      <Connect(SearchBox) />
+    </Col>
+    <Col
+      lg={6}
+      xl={5}
+    >
+      <Row
+        gutter={0}
+        justify="end"
+        type="flex"
+      >
+        <Col
+          className="nav-item-container"
+        >
+          <DropdownMenu
+            items={
+              Array [
+                Object {
+                  "display": "Reference extractor",
+                  "href": "//inspirehep.net/textmining/",
+                },
+                Object {
+                  "display": "Author list",
+                  "href": "/tools/authorlist",
+                },
+                Object {
+                  "display": "Bibliography generator",
+                  "href": "//inspirehep.net/info/hep/tools/bibliography_generate",
+                },
+              ]
+            }
+            title="Tools"
+            titleClassName="nav-item"
+          />
+        </Col>
+        <Col
+          className="nav-item-container"
+        >
+          <Link
+            className="nav-item"
+            replace={false}
+            to="/submissions/authors"
+          >
+            Submit
+          </Link>
+        </Col>
+        <Col
+          className="nav-item-container"
+        >
+          <Connect(LoginOrUserDropdownContainer) />
+        </Col>
+      </Row>
+    </Col>
+  </Row>
+</Adapter>
+`;
+
 exports[`Header renders with search box if it is not on home 1`] = `
 <Adapter
   className="__Header__"
@@ -44,12 +127,8 @@ exports[`Header renders with search box if it is not on home 1`] = `
             items={
               Array [
                 Object {
-                  "display": "Holdingpen",
-                  "to": "/holdingpen/dashboard",
-                },
-                Object {
                   "display": "Reference extractor",
-                  "href": "//inspirehep.net/textmining",
+                  "href": "//inspirehep.net/textmining/",
                 },
                 Object {
                   "display": "Author list",
@@ -129,12 +208,95 @@ exports[`Header renders without search box if it is on homepage \`/\` 1`] = `
             items={
               Array [
                 Object {
+                  "display": "Reference extractor",
+                  "href": "//inspirehep.net/textmining/",
+                },
+                Object {
+                  "display": "Author list",
+                  "href": "/tools/authorlist",
+                },
+                Object {
+                  "display": "Bibliography generator",
+                  "href": "//inspirehep.net/info/hep/tools/bibliography_generate",
+                },
+              ]
+            }
+            title="Tools"
+            titleClassName="nav-item"
+          />
+        </Col>
+        <Col
+          className="nav-item-container"
+        >
+          <Link
+            className="nav-item"
+            replace={false}
+            to="/submissions/authors"
+          >
+            Submit
+          </Link>
+        </Col>
+        <Col
+          className="nav-item-container"
+        >
+          <Connect(LoginOrUserDropdownContainer) />
+        </Col>
+      </Row>
+    </Col>
+  </Row>
+</Adapter>
+`;
+
+exports[`Header shows authorized tool links if logged in user is cataloger 1`] = `
+<Adapter
+  className="__Header__"
+>
+  <Row
+    align="middle"
+    gutter={16}
+    type="flex"
+  >
+    <Col
+      lg={5}
+    >
+      <Link
+        replace={false}
+        to="/"
+      >
+        <img
+          alt="INSPIRE Labs"
+          src="logo.svg"
+        />
+      </Link>
+    </Col>
+    <Col
+      lg={13}
+      xl={14}
+    >
+      <Connect(SearchBox) />
+    </Col>
+    <Col
+      lg={6}
+      xl={5}
+    >
+      <Row
+        gutter={0}
+        justify="end"
+        type="flex"
+      >
+        <Col
+          className="nav-item-container"
+        >
+          <DropdownMenu
+            items={
+              Array [
+                Object {
                   "display": "Holdingpen",
-                  "to": "/holdingpen/dashboard",
+                  "href": "/holdingpen",
                 },
                 Object {
                   "display": "Reference extractor",
-                  "href": "//inspirehep.net/textmining",
+                  "href": "//inspirehep.net/textmining/",
                 },
                 Object {
                   "display": "Author list",


### PR DESCRIPTION
Corrected the reference extractor link. Made HoldingPen available in the tools menu  only for non-beta users.