### PR TITLE
prefetch/render citations to display the count

### DIFF
--- a/src/common/components/TabNameWithCount/TabNameWithCount.jsx
+++ b/src/common/components/TabNameWithCount/TabNameWithCount.jsx
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from 'antd';
+
+class TabNameWithCount extends Component {
+  render() {
+    const { name, loading, count } = this.props;
+    return (
+      <span>
+        <span>{name}</span>
+        <span className="ml1">
+          {loading ? (
+            <Icon className="ml1" type="loading" spin />
+          ) : (
+            count != null && <span>({count})</span>
+          )}
+        </span>
+      </span>
+    );
+  }
+}
+
+TabNameWithCount.propTypes = {
+  name: PropTypes.string.isRequired,
+  loading: PropTypes.bool,
+  count: PropTypes.number,
+};
+
+TabNameWithCount.defaultProps = {
+  count: null,
+  loading: false,
+};
+
+export default TabNameWithCount;

--- a/src/common/components/TabNameWithCount/__tests__/TabNameWithCount.test.jsx
+++ b/src/common/components/TabNameWithCount/__tests__/TabNameWithCount.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TabNameWithCount from '../TabNameWithCount';
+
+describe('TabNameWithCount', () => {
+  it('renders with required props', () => {
+    const wrapper = shallow(<TabNameWithCount name="Test" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders when loading true', () => {
+    const wrapper = shallow(<TabNameWithCount name="Test" loading />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('does not display count if loading is true', () => {
+    const wrapper = shallow(
+      <TabNameWithCount name="Test" loading count={10} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('displays count if loading is false', () => {
+    const wrapper = shallow(
+      <TabNameWithCount name="Test" loading={false} count={10} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/common/components/TabNameWithCount/__tests__/__snapshots__/TabNameWithCount.test.jsx.snap
+++ b/src/common/components/TabNameWithCount/__tests__/__snapshots__/TabNameWithCount.test.jsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabNameWithCount displays count if loading is false 1`] = `
+<span>
+  <span>
+    Test
+  </span>
+  <span
+    className="ml1"
+  >
+    <span>
+      (
+      10
+      )
+    </span>
+  </span>
+</span>
+`;
+
+exports[`TabNameWithCount does not display count if loading is true 1`] = `
+<span>
+  <span>
+    Test
+  </span>
+  <span
+    className="ml1"
+  >
+    <Icon
+      className="ml1"
+      spin={true}
+      type="loading"
+    />
+  </span>
+</span>
+`;
+
+exports[`TabNameWithCount renders when loading true 1`] = `
+<span>
+  <span>
+    Test
+  </span>
+  <span
+    className="ml1"
+  >
+    <Icon
+      className="ml1"
+      spin={true}
+      type="loading"
+    />
+  </span>
+</span>
+`;
+
+exports[`TabNameWithCount renders with required props 1`] = `
+<span>
+  <span>
+    Test
+  </span>
+  <span
+    className="ml1"
+  />
+</span>
+`;

--- a/src/common/components/TabNameWithCount/index.js
+++ b/src/common/components/TabNameWithCount/index.js
@@ -1,0 +1,3 @@
+import TabNameWithCount from './TabNameWithCount';
+
+export default TabNameWithCount;

--- a/src/literature/containers/DetailPage/DetailPage.jsx
+++ b/src/literature/containers/DetailPage/DetailPage.jsx
@@ -31,6 +31,7 @@ import IsbnList from '../../components/IsbnList';
 import ConferenceInfoList from '../../components/ConferenceInfoList';
 import NumberOfPages from '../../components/NumberOfPages';
 import CitationListContainer from '../../../common/containers/CitationListContainer';
+import TabNameWithCount from '../../../common/components/TabNameWithCount';
 
 class DetailPage extends Component {
   componentDidMount() {
@@ -54,7 +55,14 @@ class DetailPage extends Component {
   }
 
   render() {
-    const { authors, references, loadingReferences, supervisors } = this.props;
+    const {
+      authors,
+      references,
+      loadingReferences,
+      supervisors,
+      citationCount,
+      loadingCitations,
+    } = this.props;
 
     const { record } = this.props;
     const metadata = record.get('metadata');
@@ -85,7 +93,6 @@ class DetailPage extends Component {
     const authorCount = metadata.get('author_count');
 
     const numberOfReferences = metadata.get('number_of_references');
-    const citationCount = metadata.get('citation_count');
 
     return (
       <Row className="__DetailPage__" type="flex" justify="center">
@@ -148,35 +155,41 @@ class DetailPage extends Component {
             </Row>
           </ContentBox>
         </Col>
-        {(numberOfReferences > 0 || citationCount > 0) && (
-          <Col className="mt3 mb3" span={14}>
-            <Tabs
-              type="card"
-              tabBarStyle={{ marginBottom: 0 }}
-              className="remove-top-border-of-card-children"
+        <Col className="mt3 mb3" span={14}>
+          <Tabs
+            type="card"
+            tabBarStyle={{ marginBottom: 0 }}
+            className="remove-top-border-of-card-children"
+          >
+            <Tabs.TabPane
+              tab={
+                <TabNameWithCount
+                  name="References"
+                  count={numberOfReferences}
+                />
+              }
+              key="1"
             >
-              {numberOfReferences > 0 && (
-                <Tabs.TabPane
-                  tab={`References (${numberOfReferences})`}
-                  key="1"
-                >
-                  <ReferenceList
-                    references={references}
-                    loading={loadingReferences}
-                  />
-                </Tabs.TabPane>
-              )}
-              {citationCount && (
-                <Tabs.TabPane tab={`Citations (${citationCount})`} key="2">
-                  <CitationListContainer
-                    pidType="literature"
-                    recordId={recordId}
-                  />
-                </Tabs.TabPane>
-              )}
-            </Tabs>
-          </Col>
-        )}
+              <ReferenceList
+                references={references}
+                loading={loadingReferences}
+              />
+            </Tabs.TabPane>
+            <Tabs.TabPane
+              tab={
+                <TabNameWithCount
+                  name="Citations"
+                  loading={loadingCitations}
+                  count={citationCount}
+                />
+              }
+              key="2"
+              forceRender
+            >
+              <CitationListContainer pidType="literature" recordId={recordId} />
+            </Tabs.TabPane>
+          </Tabs>
+        </Col>
       </Row>
     );
   }
@@ -191,6 +204,9 @@ DetailPage.propTypes = {
   supervisors: PropTypes.instanceOf(List).isRequired,
   loadingReferences: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
+  citationCount: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
+  loadingCitations: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -200,6 +216,8 @@ const mapStateToProps = state => ({
   loadingReferences: state.literature.get('loadingReferences'),
   authors: state.literature.get('authors'),
   supervisors: state.literature.get('supervisors'),
+  citationCount: state.citations.get('total'),
+  loadingCitations: state.citations.get('loading'),
 });
 const dispatchToProps = dispatch => ({ dispatch });
 


### PR DESCRIPTION
Now citation_count is not in response of /literature/recid, thus we
need use citations API to have total number of citations in order to
display on the tab.

It forces rendering citations tab, and use total number from state,
also displays spinner if citations are loading.