### PR TITLE
remove usage of Object.entries and String.includes

### DIFF
--- a/src/common/__tests__/__snapshots__/immutableToJS.test.jsx.snap
+++ b/src/common/__tests__/__snapshots__/immutableToJS.test.jsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`immutableToJS converts immutable props to built in js 1`] = `
+<MutableDummy
+  immutableProp={
+    Object {
+      "list": Array [
+        Object {
+          "foo": "bar1",
+        },
+        Object {
+          "foo": "bar2",
+        },
+      ],
+    }
+  }
+  mutableProp={
+    Object {
+      "array": Array [
+        Object {
+          "foo": "bar",
+        },
+      ],
+    }
+  }
+  primitiveProp="string"
+/>
+`;

--- a/src/common/__tests__/immutableToJS.test.jsx
+++ b/src/common/__tests__/immutableToJS.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { fromJS } from 'immutable';
+
+import immutableToJS from '../immutableToJS';
+
+function MutableDummy(props) {
+  return <span {...props} />;
+}
+
+const ImmutableDummy = immutableToJS(MutableDummy);
+
+describe('immutableToJS', () => {
+  it('converts immutable props to built in js', () => {
+    const immutableProp = fromJS({
+      list: [{ foo: 'bar1' }, { foo: 'bar2' }],
+    });
+    const primitiveProp = 'string';
+    const mutableProp = {
+      array: [{ foo: 'bar' }],
+    };
+    const wrapper = shallow(
+      <ImmutableDummy
+        immutableProp={immutableProp}
+        mutableProp={mutableProp}
+        primitiveProp={primitiveProp}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/common/immutableToJS.jsx
+++ b/src/common/immutableToJS.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { Iterable } from 'immutable';
 
 export default WrappedComponent => wrappedComponentProps => {
-  const propsAsJS = Object.entries(wrappedComponentProps).reduce(
-    (newProps, [key, value]) => {
+  const propsAsJS = Object.keys(wrappedComponentProps).reduce(
+    (newProps, key) => {
+      const value = wrappedComponentProps[key];
       // eslint-disable-next-line no-param-reassign
       newProps[key] = Iterable.isIterable(value) ? value.toJS() : value;
       return newProps;

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -42,7 +42,7 @@ export const initialState = fromJS({
 const searchReducer = (state = initialState, action) => {
   switch (action.type) {
     case LOCATION_CHANGE:
-      if (action.payload.pathname.includes('authors')) {
+      if (action.payload.pathname.indexOf('authors') > -1) {
         return state.set('scope', searchScopes.get('authors'));
       }
       return state.set('scope', initialState.get('scope'));


### PR DESCRIPTION
* Object.entries does not work for Safari <=10

* String.includes does not work for Yandex Browser and IE 11