### PR TITLE
increase timeout for suggester debounce tests

### DIFF
--- a/src/common/components/__tests__/Suggester.test.jsx
+++ b/src/common/components/__tests__/Suggester.test.jsx
@@ -7,7 +7,7 @@ import Suggester, { REQUEST_DEBOUNCE_MS } from '../Suggester';
 
 const mockHttp = new MockAdapter(http);
 
-function wait(milisec = REQUEST_DEBOUNCE_MS + 1) {
+function wait(milisec = REQUEST_DEBOUNCE_MS + 5) {
   return new Promise(resolve => {
     setTimeout(() => resolve(), milisec);
   });


### PR DESCRIPTION
* this fails 1-2 out of 100 on travis.