### PR TITLE
unregister service worker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { ConnectedRouter } from 'react-router-redux';
 import 'tachyons';
 import * as Sentry from '@sentry/browser';
 
+import { unregister as unregisterServiceWorker } from './registerServiceWorker';
 import { store, history } from './store';
 import App from './App';
 import './theme.less';
@@ -31,5 +32,6 @@ ReactDOM.render(
   document.getElementById('root')
 );
 
-// TODO: change to CRA 2.0 service worker script and enable
+// TODO: change to CRA 2.0 service worker script and register instead of unregistering.
 // registerServiceWorker();
+unregisterServiceWorker();


### PR DESCRIPTION
We stopped registering service worker before until our FE setup becomes
"sane". But this will fix issues for the earlier users who have service
worker already registered from the earlier versions of the app.