### PR TITLE
display author supervisor suffix

### DIFF
--- a/src/common/components/AuthorLink.jsx
+++ b/src/common/components/AuthorLink.jsx
@@ -26,13 +26,18 @@ class AuthorLink extends Component {
     return author.get('full_name');
   }
 
-  renderEditorSuffix() {
+  renderRoleSuffix() {
     const { author } = this.props;
     const roles = author.get('inspire_roles', []);
 
-    if (roles.includes('editor')) {
+    if (roles.indexOf('supervisor') > -1) {
+      return <Tooltip title="supervisor">(supervisor)</Tooltip>;
+    }
+
+    if (roles.indexOf('editor') > -1) {
       return <Tooltip title="editor">(ed.)</Tooltip>;
     }
+
     return null;
   }
 
@@ -60,7 +65,7 @@ class AuthorLink extends Component {
       <div className="di">
         <ExternalLink href={authorHref}>{this.getFullName()}</ExternalLink>
         {this.renderAffiliationsList()}
-        {this.renderEditorSuffix()}
+        {this.renderRoleSuffix()}
       </div>
     );
   }

--- a/src/common/components/__tests__/AuthorLink.test.jsx
+++ b/src/common/components/__tests__/AuthorLink.test.jsx
@@ -50,7 +50,7 @@ describe('AuthorLink', () => {
   it('renders first_name with last_name missing', () => {
     const author = fromJS({
       full_name: 'Name Full',
-      first_name: 'Name Full',
+      first_name: 'Name',
       affiliations: [
         {
           value: 'Affiliation',
@@ -95,6 +95,15 @@ describe('AuthorLink', () => {
           value: 'Affiliation',
         },
       ],
+    });
+    const wrapper = shallow(<AuthorLink recordId={12345} author={author} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders supervisor', () => {
+    const author = fromJS({
+      full_name: 'Name, Full',
+      inspire_roles: ['supervisor'],
     });
     const wrapper = shallow(<AuthorLink recordId={12345} author={author} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/common/components/__tests__/__snapshots__/AuthorLink.test.jsx.snap
+++ b/src/common/components/__tests__/__snapshots__/AuthorLink.test.jsx.snap
@@ -81,7 +81,7 @@ exports[`AuthorLink renders first_name with last_name missing 1`] = `
   <ExternalLink
     href="//inspirehep.net/author/profile/Name Full"
   >
-    Name Full 
+    Name 
   </ExternalLink>
   <span
     className="pl1"
@@ -171,5 +171,29 @@ exports[`AuthorLink renders full_name with first_name missing 1`] = `
     />
     )
   </span>
+</div>
+`;
+
+exports[`AuthorLink renders supervisor 1`] = `
+<div
+  className="di"
+>
+  <ExternalLink
+    href="//inspirehep.net/author/profile/Name, Full?recid=12345"
+  >
+    Name, Full
+  </ExternalLink>
+  <Tooltip
+    arrowPointAtCenter={false}
+    autoAdjustOverflow={true}
+    mouseEnterDelay={0.1}
+    mouseLeaveDelay={0.1}
+    placement="top"
+    prefixCls="ant-tooltip"
+    title="supervisor"
+    transitionName="zoom-big-fast"
+  >
+    (supervisor)
+  </Tooltip>
 </div>
 `;


### PR DESCRIPTION
AuthorLinks displays (supervisor) if author has supervisor role.

TECH: Uses indexOf instead of includes for browser compat.